### PR TITLE
Import new font-face mixin (regarding #83b7be9)

### DIFF
--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -9,6 +9,7 @@
 @import '2-tools/utils';
 @import '2-tools/breakpoint';
 @import '2-tools/color';
+@import '2-tools/font-face';
 
 /// Reset and/or normalize styles, box-sizing definition,
 /// etc. This is the first layer which generates actual CSS.


### PR DESCRIPTION
Hey, I've noticed that the font-face mixin is missing in the main.scss file.
If thats intended, feel free to deny this pull request :+1: 

Thank you!

Related:
https://github.com/lukaskleinschmidt/gulp-frontend/commit/83b7be93276412f78267416c2e97f9b747508d6c